### PR TITLE
MySQLのアイドルタイムアウト時にエラーとなってしまう問題に対応しました。

### DIFF
--- a/lib/mysql-connection.js
+++ b/lib/mysql-connection.js
@@ -1,7 +1,15 @@
-// mysql-connection.json
+// mysql-connection.js
 var config = require('config').database;
 var mysql = require('mysql');
-var connection = mysql.createConnection(config);
+var mysqlPool = mysql.createPool(config);
+mysqlPool.on('connection', function(connection){
+    console.log('Connected to database. connection id is ' + connection.threadId);
+});
+
+mysqlPool.on('engueue', function(){
+    console.log('Waiting for available connection slot.');
+});
+
 
 module.exports.mysql = mysql;
-module.exports.connection = connection;
+module.exports.mysqlPool = mysqlPool;

--- a/routes/admin-devices.js
+++ b/routes/admin-devices.js
@@ -6,7 +6,7 @@ var moment = require('moment');
 var config = require('config').database;
 var Device = require('../device').Device;
 var mysql = db.mysql;
-var connection = db.connection;
+var mysqlPool = db.mysqlPool;
 
 var router = express.Router();
 router.get(/^\/devices\/non_registered$/, function(req, res, next){
@@ -19,7 +19,7 @@ router.get(/^\/devices\/non_registered$/, function(req, res, next){
     }
     var cnt = 0;
     var count_devices = 'SELECT count(*) AS cnt FROM devices WHERE is_registered = 0';
-    connection.query(count_devices, function(err, results){
+    mysqlPool.query(count_devices, function(err, results){
         debug('[QUERY] ' + count_devices);
         if (err) {
             return next(new Error('erroooooooooooooooooooor'));
@@ -37,7 +37,7 @@ router.get(/^\/devices\/non_registered$/, function(req, res, next){
     // 仮登録のデバイスを取得する。ページあたり25件
     var select_devices = 'SELECT * FROM devices WHERE is_registered = 0 ORDER BY created DESC, uuid LIMIT ?, ?';
     select_devices = mysql.format(select_devices, [offset, per_page]);
-    connection.query(select_devices, function(err, results){
+    mysqlPool.query(select_devices, function(err, results){
         debug('[QUERY] ' + select_devices);
         if (err) {
             return next(new Error('erroooooooooooooooooooor'));
@@ -58,7 +58,7 @@ router.get(/^\/devices$/, function(req, res, next){
     }
     var cnt = 0;
     var count_devices = 'SELECT count(*) AS cnt FROM devices';
-    connection.query(count_devices, function(err, results){
+    mysqlPool.query(count_devices, function(err, results){
         debug('[QUERY] ' + count_devices);
         if (err) {
             return next(new Error('erroooooooooooooooooooor'));
@@ -76,7 +76,7 @@ router.get(/^\/devices$/, function(req, res, next){
     // デバイスを取得する。ページあたり25件
     var select_devices = 'SELECT * FROM devices ORDER BY created DESC, uuid LIMIT ?, ?';
     select_devices = mysql.format(select_devices, [offset, per_page]);
-    connection.query(select_devices, function(err, results){
+    mysqlPool.query(select_devices, function(err, results){
         debug('[QUERY] ' + select_devices);
         if (err) {
             return next(new Error('erroooooooooooooooooooor'));
@@ -94,7 +94,7 @@ router.post(/^\/devices\/(?:([-\w]+))\/registered$/, function(req, res, next){
 
     var update_devices = 'UPDATE devices SET is_registered = 1, is_enabled = 1, updated = ? WHERE uuid = ?';
     update_devices = mysql.format(update_devices, [now, device_uuid]);
-    connection.query(update_devices, function(err, results){
+    mysqlPool.query(update_devices, function(err, results){
         debug('[QUERY] ' + update_devices);
         if (err) {
             //log.warn('Database Error. Message: %s. Query: "%s".', err.message, update_devices);
@@ -118,7 +118,7 @@ router.post(/^\/devices\/(?:([-\w]+))\/enabled$/, function(req, res, next){
 
     var update_devices = 'UPDATE devices SET is_enabled = 1, updated = ? WHERE uuid = ?';
     update_devices = mysql.format(update_devices, [now, device_uuid]);
-    connection.query(update_devices, function(err, results){
+    mysqlPool.query(update_devices, function(err, results){
         debug('[QUERY] ' + update_devices);
         if (err) {
             //log.warn('Database Error. Message: %s. Query: "%s".', err.message, update_devices);
@@ -142,7 +142,7 @@ router.post(/^\/devices\/(?:([-\w]+))\/disabled$/, function(req, res, next){
 
     var update_devices = 'UPDATE devices SET is_enabled = 0, updated = ? WHERE uuid = ?';
     update_devices = mysql.format(update_devices, [now, device_uuid]);
-    connection.query(update_devices, function(err, results){
+    mysqlPool.query(update_devices, function(err, results){
         debug('[QUERY] ' + update_devices);
         if (err) {
             //log.warn('Database Error. Message: %s. Query: "%s".', err.message, update_devices);

--- a/routes/admin-home.js
+++ b/routes/admin-home.js
@@ -5,7 +5,7 @@ var db = require('../lib/mysql-connection');
 var moment = require('moment');
 var config = require('config').database;
 var mysql = db.mysql;
-var connection = db.connection;
+var mysqlPool = db.mysqlPool;
 
 var router = express.Router();
 router.get(/^\/$/, function(req, res, next){

--- a/routes/admin-login.js
+++ b/routes/admin-login.js
@@ -6,7 +6,7 @@ var moment = require('moment');
 var crypto = require('crypto');
 var config = require('config').database;
 var mysql = db.mysql;
-var connection = db.connection;
+var mysqlPool = db.mysqlPool;
 
 var router = express.Router();
 router.get(/^\/$/, function(req, res, next){
@@ -30,7 +30,7 @@ router.post(/^\/login$/, function(req, res, next){
     var hashed_password = crypto.createHash('sha256').update(req.body.password).digest('hex');
     var select_admin_accounts = 'SELECT * FROM admin_accounts WHERE is_enabled = 1 AND account_id = ? AND hashed_password = ?';
     select_admin_accounts = mysql.format(select_admin_accounts, [account, hashed_password]);
-    connection.query(select_admin_accounts, function(err, results){
+    mysqlPool.query(select_admin_accounts, function(err, results){
         debug('[QUERY] ' + select_admin_accounts);
         console.log(results);
         console.log(results.length);

--- a/routes/admin-logs.js
+++ b/routes/admin-logs.js
@@ -5,7 +5,7 @@ var db = require('../lib/mysql-connection');
 var moment = require('moment');
 var config = require('config').database;
 var mysql = db.mysql;
-var connection = db.connection;
+var mysqlPool = db.mysqlPool;
 
 var router = express.Router();
 router.get(/^\/logs$/, function(req, res, next){
@@ -18,7 +18,7 @@ router.get(/^\/logs$/, function(req, res, next){
     }
     var cnt = 0;
     var count_logs = 'SELECT count(*) AS cnt FROM operation_logs';
-    connection.query(count_logs, function(err, results){
+    mysqlPool.query(count_logs, function(err, results){
         debug('[QUERY] ' + count_logs);
         if (err) {
             return next(new Error('erroooooooooooooooooooor'));
@@ -36,7 +36,7 @@ router.get(/^\/logs$/, function(req, res, next){
     // ログを取得する。ページあたり25件
     var select_logs = 'SELECT * FROM operation_logs ORDER BY operation_datetime DESC, id DESC LIMIT ?, ?';
     select_logs = mysql.format(select_logs, [offset, per_page]);
-    connection.query(select_logs, function(err, results){
+    mysqlPool.query(select_logs, function(err, results){
         debug('[QUERY] ' + select_logs);
         if (err) {
             return next(new Error('erroooooooooooooooooooor'));

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -6,7 +6,7 @@ var moment = require('moment');
 var config = require('config').database;
 var Device = require('../device').Device;
 var mysql = db.mysql;
-var connection = db.connection;
+var mysqlPool = db.mysqlPool;
 
 var router = express.Router();
 router.post(/^\/v1\/devices$/, function(req, res, next){
@@ -46,7 +46,7 @@ router.post(/^\/v1\/devices$/, function(req, res, next){
     // 登録データを確認する。
     var selectDevices = 'SELECT uuid, name, is_registered, is_enabled FROM devices WHERE uuid = ?';
     selectDevices = mysql.format(selectDevices, [deviceUuid]);
-    connection.query(selectDevices, function(err, rows, fields){
+    mysqlPool.query(selectDevices, function(err, rows, fields){
         debug('[QUERY] ' + selectDevices);
         if (err) {
             // log.warn('Database Error. Message: %s. Query: "%s".', err.message, selectDevices);
@@ -65,7 +65,7 @@ router.post(/^\/v1\/devices$/, function(req, res, next){
             now = moment().format('YYYY-MM-DD HH:mm:ss');
             var insertDevices = 'INSERT INTO devices (uuid, name, key_lock_code, created, updated) VALUES (?, ?, ?, ?, ?)';
             insertDevices = mysql.format(insertDevices, [deviceUuid, deviceName, keyLockCode, now, now]);
-            connection.query(insertDevices, function(err, results){
+            mysqlPool.query(insertDevices, function(err, results){
                 debug('[QUERY] ' + insertDevices);
                 if (err) {
                     //log.warn('Database Error. Message: %s. Query: "%s".', err.message, insertDevices);
@@ -96,7 +96,7 @@ router.post(/^\/v1\/devices$/, function(req, res, next){
             now = moment().format('YYYY-MM-DD HH:mm:ss');
             var updateDevices = 'UPDATE devices SET name = ?, key_lock_code = ?, is_registered = ?, is_enabled = ?, updated = ? WHERE uuid = ?';
             updateDevices = mysql.format(updateDevices, [deviceName, keyLockCode, 0, 0, now, deviceUuid]);
-            connection.query(updateDevices, function(err, results){
+            mysqlPool.query(updateDevices, function(err, results){
                 debug('[QUERY] ' + updateDevices);
                 if (err) {
                     //log.warn('Database Error. Message: %s. Query: "%s".', err.message, updateDevices);


### PR DESCRIPTION
#3 に関する対応となります。

アイドルコネクションがMySQL側から切断された場合にエラーとなり、サーバーが再起動している問題を修正しました。
（再起動しているのは、foreverの機能）
- mysqlモジュールの「Pooling connections」機能を利用するように変更しました。
  - 上記機能で、切断されてもエラーとならない。
  - また、MySQLへの再接続も必要なタイミング（クエリの発行時など）で実施される。

また、タイムアウトまでの時間は以下のMySQLコマンドで確認変更ができます。

```
    show global variables like '%timeout%';
    set global wait_timeout=60;
```
