### PR TITLE
端末一覧で有効な端末のみ表示できるように機能追加を行いました。

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -46,38 +46,30 @@ $(function(){
 
   //次へボタン
   $('#btn-next').on('click', function(){
-    if (($(this).data('show')%5) == 0) {
-      var num = Math.floor($(this).data('show')/5)*5+1
+    if (($(this).data('show') % 5) == 0) {
+      var num = Math.floor($(this).data('show') / 5) * 5 + 1;
     } else {
-      var num = Math.floor(($(this).data('show')+5)/5)*5+1
+      var num = Math.floor(($(this).data('show') + 5) / 5) * 5 + 1;
     }
     console.log(num);
     if (num < $(this).data('page')) {
-      if ($(this).data('register') == 'registered') {
-        location.href = '/admin/devices?page='+num;
-      } else {
-        location.href = '/admin/devices/non_registered?page='+num;
-      }
+      location.href = location.pathname + '?page=' + num;
     }
   });
 
   //前へボタン
   $('#btn-back').on('click', function(){
     if ((($(this).data('show'))%5) == 0) {
-      var num = Math.floor(($(this).data('show'))/5)*5-9
+      var num = Math.floor(($(this).data('show')) / 5) * 5 - 9;
     } else {
-      var num = Math.floor(($(this).data('show')-5)/5)*5+1
+      var num = Math.floor(($(this).data('show') - 5) / 5) * 5 + 1;
     }
     console.log(num);
     if (num >= 1) {
-      if ($(this).data('register') == 'registered') {
-        location.href = '/admin/devices?page='+num;
-      } else {
-        location.href = '/admin/devices/non_registered?page='+num;
-      }
+      location.href = location.pathname + '?page=' + num;
     }
   });
-  
+
   //次へボタン
   $('#logs-btn-next').on('click', function(){
     if (($(this).data('show')%5) == 0) {

--- a/routes/admin-devices.js
+++ b/routes/admin-devices.js
@@ -7,13 +7,15 @@ var config = require('config').database;
 var Device = require('../device').Device;
 var mysql = db.mysql;
 var connection = db.connection;
-
 var router = express.Router();
+
+// 1ページあたりの表示件数
+var default_per_page = 25;
 
 // 仮登録の端末一覧を取得・表示する。
 router.get(/^\/devices\/non_registered$/, function(req, res, next){
     var params = {};
-    var per_page = 25;
+    var per_page = default_per_page;
     var page = 1;
     var query = req.query;
     if (query.page !== undefined && query.page != 0) {
@@ -31,7 +33,6 @@ router.get(/^\/devices\/non_registered$/, function(req, res, next){
         var totalPage = Math.ceil(cnt / per_page);
         params['totalPage'] = totalPage;
         params['page'] = page;
-        params['register'] = 'non_registered';
         console.log(totalPage);
     });
     var offset = 0;
@@ -53,7 +54,7 @@ router.get(/^\/devices\/non_registered$/, function(req, res, next){
 // 登録されている端末一覧を取得・表示する。
 router.get(/^\/devices\/all$/, function(req, res, next){
     var params = {};
-    var per_page = 25;
+    var per_page = default_per_page;
     var page = 1;
     var query = req.query;
 
@@ -72,7 +73,6 @@ router.get(/^\/devices\/all$/, function(req, res, next){
         var totalPage = Math.ceil(cnt / per_page);
         params['totalPage'] = totalPage;
         params['page'] = page;
-        params['register'] = 'registered';
         console.log(totalPage);
     });
     var offset = 0;
@@ -94,7 +94,7 @@ router.get(/^\/devices\/all$/, function(req, res, next){
 // 有効な端末一覧を取得・表示する。
 router.get([/^\/devices$/, /^\/devices\/enabled$/], function(req, res, next){
     var params = {};
-    var per_page = 25;
+    var per_page = default_per_page;
     var page = 1;
     var query = req.query;
 
@@ -113,7 +113,6 @@ router.get([/^\/devices$/, /^\/devices\/enabled$/], function(req, res, next){
         var totalPage = Math.ceil(cnt / per_page);
         params['totalPage'] = totalPage;
         params['page'] = page;
-        params['register'] = 'registered';
         console.log(totalPage);
     });
     var offset = 0;

--- a/routes/admin-devices.js
+++ b/routes/admin-devices.js
@@ -21,32 +21,29 @@ router.get(/^\/devices\/non_registered$/, function(req, res, next){
     if (query.page !== undefined && query.page != 0) {
         page = parseInt(query.page);
     }
-    var cnt = 0;
-    var count_devices = 'SELECT count(*) AS cnt FROM devices WHERE is_registered = 0';
+
+    var count_devices = 'SELECT COUNT(*) AS cnt FROM devices WHERE is_registered = 0';
     connection.query(count_devices, function(err, results){
         debug('[QUERY] ' + count_devices);
         if (err) {
             return next(new Error('erroooooooooooooooooooor'));
         }
-        cnt = results[0].cnt;
-        console.log(results[0].cnt);
-        var totalPage = Math.ceil(cnt / per_page);
-        params['totalPage'] = totalPage;
+        params['totalPage'] = Math.ceil(results[0].cnt / per_page);
         params['page'] = page;
-        console.log(totalPage);
-    });
-    var offset = 0;
-    offset = (page - 1) * per_page;
-    // 仮登録のデバイスを取得する。ページあたり25件
-    var select_devices = 'SELECT * FROM devices WHERE is_registered = 0 ORDER BY created DESC, uuid LIMIT ?, ?';
-    select_devices = mysql.format(select_devices, [offset, per_page]);
-    connection.query(select_devices, function(err, results){
-        debug('[QUERY] ' + select_devices);
-        if (err) {
-            return next(new Error('erroooooooooooooooooooor'));
-        }
-        params['devices'] = results;
-        res.render('admin-devices', params);
+        debug('[TotalPageNo] ' + params['totalPage']);
+
+        var offset = (page - 1) * per_page;
+        // 仮登録のデバイスを取得する。ページあたり25件
+        var select_devices = 'SELECT * FROM devices WHERE is_registered = 0 ORDER BY created DESC, uuid LIMIT ?, ?';
+        select_devices = mysql.format(select_devices, [offset, per_page]);
+        connection.query(select_devices, function(err, results){
+            debug('[QUERY] ' + select_devices);
+            if (err) {
+                return next(new Error('erroooooooooooooooooooor'));
+            }
+            params['devices'] = results;
+            res.render('admin-devices', params);
+        });
     });
 });
 
@@ -57,36 +54,32 @@ router.get(/^\/devices\/all$/, function(req, res, next){
     var per_page = default_per_page;
     var page = 1;
     var query = req.query;
-
     if (query.page !== undefined && query.page != 0) {
         page = parseInt(query.page);
     }
-    var cnt = 0;
-    var count_devices = 'SELECT count(*) AS cnt FROM devices';
+
+    var count_devices = 'SELECT COUNT(*) AS cnt FROM devices';
     connection.query(count_devices, function(err, results){
         debug('[QUERY] ' + count_devices);
         if (err) {
             return next(new Error('erroooooooooooooooooooor'));
         }
-        cnt = results[0].cnt;
-        console.log(results[0].cnt);
-        var totalPage = Math.ceil(cnt / per_page);
-        params['totalPage'] = totalPage;
+        params['totalPage'] = Math.ceil(results[0].cnt / per_page);
         params['page'] = page;
-        console.log(totalPage);
-    });
-    var offset = 0;
-    offset = (page - 1) * per_page;
-    // デバイスを取得する。ページあたり25件
-    var select_devices = 'SELECT * FROM devices ORDER BY created DESC, uuid LIMIT ?, ?';
-    select_devices = mysql.format(select_devices, [offset, per_page]);
-    connection.query(select_devices, function(err, results){
-        debug('[QUERY] ' + select_devices);
-        if (err) {
-            return next(new Error('erroooooooooooooooooooor'));
-        }
-        params['devices'] = results;
-        res.render('admin-devices', params);
+        debug('[TotalPageNo] ' + params['totalPage']);
+
+        var offset = (page - 1) * per_page;
+        // 全デバイスを取得する。ページあたり25件
+        var select_devices = 'SELECT * FROM devices ORDER BY created DESC, uuid LIMIT ?, ?';
+        select_devices = mysql.format(select_devices, [offset, per_page]);
+        connection.query(select_devices, function(err, results){
+            debug('[QUERY] ' + select_devices);
+            if (err) {
+                return next(new Error('erroooooooooooooooooooor'));
+            }
+            params['devices'] = results;
+            res.render('admin-devices', params);
+        });
     });
 });
 
@@ -97,36 +90,32 @@ router.get([/^\/devices$/, /^\/devices\/enabled$/], function(req, res, next){
     var per_page = default_per_page;
     var page = 1;
     var query = req.query;
-
     if (query.page !== undefined && query.page != 0) {
         page = parseInt(query.page);
     }
-    var cnt = 0;
-    var count_devices = 'SELECT count(*) AS cnt FROM devices WHERE is_enabled = 1';
+
+    var count_devices = 'SELECT COUNT(*) AS cnt FROM devices WHERE is_enabled = 1';
     connection.query(count_devices, function(err, results){
         debug('[QUERY] ' + count_devices);
         if (err) {
             return next(new Error('erroooooooooooooooooooor'));
         }
-        cnt = results[0].cnt;
-        console.log(results[0].cnt);
-        var totalPage = Math.ceil(cnt / per_page);
-        params['totalPage'] = totalPage;
+        params['totalPage'] = Math.ceil(results[0].cnt / per_page);
         params['page'] = page;
-        console.log(totalPage);
-    });
-    var offset = 0;
-    offset = (page - 1) * per_page;
-    // デバイスを取得する。ページあたり25件
-    var select_devices = 'SELECT * FROM devices WHERE is_enabled = 1 ORDER BY created DESC, uuid LIMIT ?, ?';
-    select_devices = mysql.format(select_devices, [offset, per_page]);
-    connection.query(select_devices, function(err, results){
-        debug('[QUERY] ' + select_devices);
-        if (err) {
-            return next(new Error('erroooooooooooooooooooor'));
-        }
-        params['devices'] = results;
-        res.render('admin-devices', params);
+        debug('[TotalPageNo] ' + params['totalPage']);
+
+        var offset = (page - 1) * per_page;
+        // 有効なデバイスを取得する。ページあたり25件
+        var select_devices = 'SELECT * FROM devices WHERE is_enabled = 1 ORDER BY created DESC, uuid LIMIT ?, ?';
+        select_devices = mysql.format(select_devices, [offset, per_page]);
+        connection.query(select_devices, function(err, results){
+            debug('[QUERY] ' + select_devices);
+            if (err) {
+                return next(new Error('erroooooooooooooooooooor'));
+            }
+            params['devices'] = results;
+            res.render('admin-devices', params);
+        });
     });
 });
 

--- a/views/admin-devices.ect
+++ b/views/admin-devices.ect
@@ -96,7 +96,7 @@
         <% end %>
       <% end %>
       <% if (@page%5) != 0 : %>
-        <% if Math.floor(@page/5) >= Math.floor(@totalPage/5) : %>
+        <% if Math.ceil(@page / 5) >= Math.ceil(@totalPage / 5) : %>
             <li class="disabled">
               <a id="btn-next" data-show="<%= @page %>" aria-label="Next">
                 <span aria-hidden="true">&raquo;</span>

--- a/views/admin-devices.ect
+++ b/views/admin-devices.ect
@@ -50,13 +50,13 @@
       <% if (@page%5) != 0 : %>
         <% if Math.floor(@page/5) == 0 : %>
           <li class="disabled">
-            <a id="btn-back" data-register="<%= @register %>" data-show="<%= @page %>" aria-label="Previous">
+            <a id="btn-back" data-show="<%= @page %>" aria-label="Previous">
               <span aria-hidden="true">&laquo;</span>
             </a>
           </li>
         <% else : %>
           <li>
-            <a id="btn-back" data-register="<%= @register %>" data-show="<%= @page %>" aria-label="Previous">
+            <a id="btn-back" data-show="<%= @page %>" aria-label="Previous">
               <span aria-hidden="true">&laquo;</span>
             </a>
           </li>
@@ -64,13 +64,13 @@
       <% else : %>
         <% if @page == 5 : %>
           <li class="disabled">
-            <a id="btn-back" data-register="<%= @register %>" data-show="<%= @page %>" aria-label="Previous">
+            <a id="btn-back" data-show="<%= @page %>" aria-label="Previous">
               <span aria-hidden="true">&laquo;</span>
             </a>
           </li>
         <% else : %>
           <li>
-            <a id="btn-back" data-register="<%= @register %>" data-show="<%= @page %>" aria-label="Previous">
+            <a id="btn-back" data-show="<%= @page %>" aria-label="Previous">
               <span aria-hidden="true">&laquo;</span>
             </a>
           </li>
@@ -79,34 +79,18 @@
       <% for i in [1..5] : %>
         <% if (@page%5) != 0 : %>
           <% if Math.floor(@page/5)*5+i <= @totalPage : %>
-            <% if @register == "registered" : %>
-              <% if @page == Math.floor(@page/5)*5+i : %>
-                <li class="active"><a href="/admin/devices?page=<%- Math.floor(@page/5)*5+i %>"><%= Math.floor(@page/5)*5+i %></a></li>
-              <% else : %>
-                <li><a href="/admin/devices?page=<%- Math.floor(@page/5)*5+i %>"><%= Math.floor(@page/5)*5+i %></a></li>
-              <% end %>
-            <% else if @register == "non_registered" : %>
-              <% if @page == Math.floor(@page/5)*5+i : %>
-                <li class="active"><a href="/admin/devices/non_registered?page=<%- Math.floor(@page/5)*5+i %>"><%= Math.floor(@page/5)*5+i %></a></li>
-              <% else : %>
-                <li><a href="/admin/devices/non_registered?page=<%- Math.floor(@page/5)*5+i %>"><%= Math.floor(@page/5)*5+i %></a></li>
-              <% end %>
+            <% if @page == Math.floor(@page/5)*5+i : %>
+              <li class="active"><a href="?page=<%- Math.floor(@page/5)*5+i %>"><%= Math.floor(@page/5)*5+i %></a></li>
+            <% else : %>
+              <li><a href="?page=<%- Math.floor(@page/5)*5+i %>"><%= Math.floor(@page/5)*5+i %></a></li>
             <% end %>
           <% end %>
         <% else : %>
           <% if Math.floor(@page/5)*5+i-5 <= @totalPage : %>
-            <% if @register == "registered" : %>
-              <% if @page == Math.floor(@page/5)*5+i-5 : %>
-                <li class="active"><a href="/admin/devices?page=<%- Math.floor(@page/5)*5+i-5 %>"><%= Math.floor(@page/5)*5+i-5 %></a></li>
-              <% else : %>
-                <li><a href="/admin/devices?page=<%- Math.floor(@page/5)*5+i-5 %>"><%= Math.floor(@page/5)*5+i-5 %></a></li>
-              <% end %>
-            <% else if @register == "non_registered" : %>
-              <% if @page == Math.floor(@page/5)*5+i-5 : %>
-                <li class="active"><a href="/admin/devices/non_registered?page=<%- Math.floor(@page/5)*5+i-5 %>"><%= Math.floor(@page/5)*5+i-5 %></a></li>
-              <% else : %>
-                <li><a href="/admin/devices/non_registered?page=<%- Math.floor(@page/5)*5+i-5 %>"><%= Math.floor(@page/5)*5+i-5 %></a></li>
-              <% end %>
+            <% if @page == Math.floor(@page/5)*5+i-5 : %>
+              <li class="active"><a href="page=<%- Math.floor(@page/5)*5+i-5 %>"><%= Math.floor(@page/5)*5+i-5 %></a></li>
+            <% else : %>
+              <li><a href="?page=<%- Math.floor(@page/5)*5+i-5 %>"><%= Math.floor(@page/5)*5+i-5 %></a></li>
             <% end %>
           <% end %>
         <% end %>
@@ -114,20 +98,20 @@
       <% if (@page%5) != 0 : %>
         <% if Math.floor(@page/5) >= Math.floor(@totalPage/5) : %>
             <li class="disabled">
-              <a id="btn-next" data-register="<%= @register %>" data-show="<%= @page %>" aria-label="Next">
+              <a id="btn-next" data-show="<%= @page %>" aria-label="Next">
                 <span aria-hidden="true">&raquo;</span>
               </a>
             </li>
         <% else : %>
           <li>
-            <a id="btn-next" data-page="<%= @totalPage %>" data-register="<%= @register %>" data-show="<%= @page %>" aria-label="Next">
+            <a id="btn-next" data-page="<%= @totalPage %>" data-show="<%= @page %>" aria-label="Next">
               <span aria-hidden="true">&raquo;</span>
             </a>
           </li>
         <% end %>
       <% else : %>
         <li>
-          <a id="btn-next" data-page="<%= @totalPage %>" data-register="<%= @register %>" data-show="<%= @page %>" aria-label="Next">
+          <a id="btn-next" data-page="<%= @totalPage %>" data-show="<%= @page %>" aria-label="Next">
             <span aria-hidden="true">&raquo;</span>
           </a>
         </li>

--- a/views/admin-header-nav.ect
+++ b/views/admin-header-nav.ect
@@ -16,8 +16,9 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Devices <span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="/admin/devices">All</a></li>
+                <li><a href="/admin/devices">Enabled</a></li>
                 <li><a href="/admin/devices/non_registered">Non Registered</a></li>
+                <li><a href="/admin/devices/all">All</a></li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
#1 に関する対応となります。
- 有効となっている端末のみ表示できるようにURLを修正、追加、変更を行いました。
1. すべての端末を表示 `/admin/devices/all`
2. 有効な端末を表示 `/admin/devices` もしくは、 `/admin/devices/enabled`
3. 仮登録の端末を表示 `/admin/devices/non_registered`
- 機能追加した周辺コードの整理を行いました。
1. ページネーションの不具合の修正
2. 非同期処理に関する考慮漏れを修正

以上、ご確認お願いします！
